### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,5 +1,9 @@
 name: Build and Test
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/logan-han/tax-invoice/security/code-scanning/1](https://github.com/logan-han/tax-invoice/security/code-scanning/1)

To fix the issue, add a `permissions` block to the root of the workflow file. This block will define the least privileges required for the workflow to function correctly. Based on the workflow's tasks, the following permissions are appropriate:
- `contents: read` for reading repository contents.
- `pull-requests: write` for interacting with pull requests (if necessary).
- No additional permissions are required for the external services (Codecov and AWS S3) as they use secrets.

The `permissions` block should be added at the top level of the workflow file, ensuring it applies to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
